### PR TITLE
Update bruker.jl

### DIFF
--- a/src/NMRIO/bruker.jl
+++ b/src/NMRIO/bruker.jl
@@ -113,7 +113,7 @@ function loadpdata(filename, allcomponents=false)
             elseif w == 1
                 window = ExponentialWindow(procdic[:lb], dic[:aq])
             elseif w == 2
-                warn("Gaussian window not yet implemented")
+                @warn("Gaussian window not yet implemented")
                 window = UnknownWindow(dic[:aq])
             elseif w == 3
                 ssb = procdic[:ssb]


### PR DESCRIPTION
Fixes an error raised when a Bruker file is loaded with a Gaussian window flag set: corrects spurious warn &rarr; @warn macro reference