### PR TITLE
Fix cross-reference resolution errors in documentation build

### DIFF
--- a/docs/src/metadata/samples.md
+++ b/docs/src/metadata/samples.md
@@ -103,8 +103,6 @@ s = findsample(expts[1], samples)   # faster — uses pre-scanned list
 group = findexperiments(samples[1], expts)
 ```
 
-See [Scanning experiments](@ref) for a full guide to the scanning API.
-
 ## Reference
 
 ```@docs; canonical=false

--- a/src/NMRIO/experiment.jl
+++ b/src/NMRIO/experiment.jl
@@ -6,7 +6,7 @@ Reads acqus, title, and pulse programme (text files only) — no binary data loa
 Annotations are parsed from the pulse programme YAML but parameter references are
 not resolved (full resolution happens in `loadnmr`).
 
-See also: [`scanexperiments`](@ref), [`loadnmr`](@ref).
+See also: [`scanexperiments`](@ref NMRTools.NMRIO.scanexperiments), [`loadnmr`](@ref NMRTools.NMRIO.loadnmr).
 """
 function NMRExperiment(experimentfolder::AbstractString)
     path = abspath(experimentfolder)

--- a/src/NMRIO/scan.jl
+++ b/src/NMRIO/scan.jl
@@ -29,7 +29,7 @@ cest = filter(e -> "cest" in get(annotations(e), "experiment_type", []), expts)
 spec = loadnmr(expts[1])
 ```
 
-See also: [`NMRExperiment`](@ref), [`scansamples`](@ref), [`findexperiments`](@ref).
+See also: [`NMRExperiment`](@ref), [`scansamples`](@ref NMRTools.NMRIO.scansamples), [`findexperiments`](@ref NMRTools.NMRIO.findexperiments).
 """
 function scanexperiments(dir::AbstractString;
                          recursive::Bool=true,
@@ -85,7 +85,7 @@ the sample's creation–ejection timestamp window.
 - With a directory path, calls `scanexperiments(dir; kw...)` then filters.
 - With a pre-scanned `Vector{NMRExperiment}`, filters without any disk I/O.
 
-See also: [`scanexperiments`](@ref), [`findsample`](@ref).
+See also: [`scanexperiments`](@ref NMRTools.NMRIO.scanexperiments), [`findsample`](@ref NMRTools.NMRIO.findsample).
 """
 function findexperiments(sample::NMRSample; kw...)::Vector{NMRExperiment}
     findexperiments(sample, dirname(samplefile(sample)); kw...)


### PR DESCRIPTION
Documenter v1.x requires fully-qualified module paths for @ref links
when the binding is only findable via fallback resolution outside the
current module context. NMRIO functions (scansamples, findsample,
scanexperiments, findexperiments, loadnmr) were referenced unqualified
from docstrings resolved in the NMRBase context.

- Update @ref links in scan.jl and experiment.jl docstrings to use
  NMRTools.NMRIO.<name> qualified forms
- Remove broken [Scanning experiments](@ref) link in samples.md
  (no matching section existed)

https://claude.ai/code/session_013LrL2BA1pjvp6VEYDBLFDR