### PR TITLE
Fix documentation cross-reference errors

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 **Documentation:**
 - `julia make-local-docs.jl` — build documentation locally (installs package in dev mode and runs docs/make.jl)
 - Documentation uses Documenter.jl with visual regression tests for plots
+- Do not add "Reference" sections (with `@docs` or `@autodocs` blocks) to doc pages — all API reference lives in `docs/src/api.md` only
+- Documenter.jl resolves `@ref` links in the context of the module where a docstring is defined. When a docstring in `NMRBase` references a function in `NMRIO`, the unqualified `@ref` fails. Use the fully-qualified form: `` [`name`](@ref NMRTools.NMRIO.name) ``
 
 **Package Management:**
 - Standard Julia package — use `] dev .` to develop locally

--- a/docs/src/metadata/samples.md
+++ b/docs/src/metadata/samples.md
@@ -92,8 +92,8 @@ expts = scanexperiments("/nmr/projects/lysozyme/")
 hassample(expts[1])
 sample(expts[1], "sample", "label")
 
-# Scan all sample files in a directory
-samples = scansamples("/nmr/samples/")
+# Scan all sample files in the same directory (sample JSONs live alongside experiment folders)
+samples = scansamples("/nmr/projects/lysozyme/")
 
 # Find the sample matching a specific experiment
 s = findsample(expts[1])
@@ -101,18 +101,4 @@ s = findsample(expts[1], samples)   # faster — uses pre-scanned list
 
 # Find all experiments for a given sample
 group = findexperiments(samples[1], expts)
-```
-
-## Reference
-
-```@docs; canonical=false
-NMRSample
-NMRExperiment
-sample
-hassample
-samplefile
-scansamples
-scanexperiments
-findsample
-findexperiments
 ```

--- a/src/NMRBase/nmrdata.jl
+++ b/src/NMRBase/nmrdata.jl
@@ -16,7 +16,7 @@ abstract type AbstractNMRData{T,N,D,A} <: AbstractDimArray{T,N,D,A} end
 A lightweight wrapper around an NMR sample JSON file. Holds the file path and
 parsed metadata. Access fields via [`sample`](@ref).
 
-See also: [`scansamples`](@ref), [`findsample`](@ref).
+See also: [`scansamples`](@ref NMRTools.NMRIO.scansamples), [`findsample`](@ref NMRTools.NMRIO.findsample).
 """
 struct NMRSample
     path::String
@@ -29,7 +29,7 @@ end
 A lightweight, metadata-only descriptor for a Bruker NMR experiment folder.
 Does not load any binary data. Upgrade to a full [`NMRData`](@ref) via `loadnmr`.
 
-See also: [`scanexperiments`](@ref), [`findsample`](@ref), [`loadnmr`](@ref).
+See also: [`scanexperiments`](@ref NMRTools.NMRIO.scanexperiments), [`findsample`](@ref NMRTools.NMRIO.findsample), [`loadnmr`](@ref NMRTools.NMRIO.loadnmr).
 """
 struct NMRExperiment
     path::String

--- a/src/NMRIO/loadnmr.jl
+++ b/src/NMRIO/loadnmr.jl
@@ -122,7 +122,7 @@ end
 """
     loadnmr(expt::NMRExperiment; pdatadir=1, allcomponents=false) -> NMRData
 
-Load the full NMR spectrum for an experiment previously discovered by [`scanexperiments`](@ref).
+Load the full NMR spectrum for an experiment previously discovered by [`scanexperiments`](@ref NMRTools.NMRIO.scanexperiments).
 """
 function loadnmr(expt::NMRExperiment; pdatadir::Int=1, allcomponents::Bool=false)
     return loadnmr(joinpath(expt.path, "pdata", string(pdatadir)); allcomponents)


### PR DESCRIPTION
## Summary

- Fix all `@ref` cross-reference errors that were failing the docs build. The root cause was docstrings in `NMRBase` (the `NMRSample` and `NMRExperiment` struct docstrings) and `NMRIO/loadnmr.jl` referencing NMRIO functions unqualified — Documenter v1.x resolves `@ref` in the defining module's context, so NMRBase can't see NMRIO functions. Fixed using the explicit-target form: `` [`name`](@ref NMRTools.NMRIO.name) ``
- Remove `## Reference` / `@docs` block from `docs/src/metadata/samples.md` — API reference belongs in `api.md` only
- Fix `scansamples` example path: sample JSON files live alongside numbered experiment folders in the same directory, not in a separate location
- Document both conventions in `CLAUDE.md`

## Test plan

- [ ] Docs build passes (no `[:cross_references]` error)
- [ ] `samples.md` renders correctly without a Reference section
