### PR TITLE
PlotsExt: add Multicomplex element type support (#55)

### DIFF
--- a/ext/PlotsExt.jl
+++ b/ext/PlotsExt.jl
@@ -36,26 +36,8 @@ function axislabel(dim::NMRDimension)
     end
 end
 
-# Multicomplex preprocessing: extract real part before delegating to existing recipes
-@recipe function f(A::NMRData{<:Multicomplex,1,Tuple{D}}) where {D<:FrequencyDimension}
-    rebuild(A; data=realest.(parent(A)))
-end
-
-@recipe function f(A::NMRData{<:Multicomplex,1,Tuple{D}}) where {D<:NonFrequencyDimension}
-    rebuild(A; data=realest.(parent(A)))
-end
-
-@recipe function f(A::NMRData{<:Multicomplex,2})
-    rebuild(A; data=realest.(parent(A)))
-end
-
-@recipe function f(v::Vector{<:NMRData{<:Multicomplex,1}})
-    [rebuild(A; data=realest.(parent(A))) for A in v]
-end
-
-@recipe function f(v::Vector{D}) where {D<:NMRData{<:Multicomplex,2}}
-    [rebuild(A; data=realest.(parent(A))) for A in v]
-end
+_realdata(A::AbstractNMRData) = data(A)
+_realdata(A::AbstractNMRData{<:Multicomplex}) = realest.(data(A))
 
 # 1D plot (frequency)
 @recipe function f(A::NMRData{T,1,Tuple{D}}; normalize=true) where {T,D<:FrequencyDimension}
@@ -85,7 +67,7 @@ end
     scaling = (normalize !== false) ? scale(Afwd) : 1
 
     delete!(plotattributes, :normalize)
-    return data(x), data(Afwd) ./ scaling
+    return data(x), _realdata(Afwd) ./ scaling
 end
 
 # 1D plot (non-frequency)
@@ -134,7 +116,7 @@ end
 
     scaling = (normalize !== false) ? scale(Afwd) : 1
     delete!(plotattributes, :normalize)
-    return data(x), data(Afwd) ./ scaling
+    return data(x), _realdata(Afwd) ./ scaling
 end
 
 # multiple 1D plots
@@ -190,7 +172,7 @@ end
             Afwd = reorder(A, ForwardOrdered) # make sure data axes are in forwards order
             x = dims(Afwd, 1)
             label --> label(A)
-            data(x), data(Afwd) ./ scaling .+ voffset
+            data(x), _realdata(Afwd) ./ scaling .+ voffset
         end
         voffset += vdelta
     end
@@ -248,7 +230,7 @@ end
     stype = get(plotattributes, :seriestype, nothing)
     if stype ∈ [:heatmap, :wireframe]
         # heatmap
-        data(x), data(y), permutedims(data(dfwd))
+        data(x), data(y), permutedims(_realdata(dfwd))
     else
         poscolor = get(plotattributes, :poscolor, nothing)
         negcolor_arg = get(plotattributes, :negcolor, nothing)
@@ -277,14 +259,14 @@ end
             levels --> 5σ .* contourlevels()
             seriescolor := poscolor_c
             primary --> true
-            data(x), data(y), permutedims(data(dfwd))
+            data(x), data(y), permutedims(_realdata(dfwd))
         end
         if negcontours
             @series begin
                 levels --> -5σ .* contourlevels()
                 seriescolor := negcolor_c
                 primary := false
-                data(x), data(y), permutedims(data(dfwd))
+                data(x), data(y), permutedims(_realdata(dfwd))
             end
         end
     end
@@ -332,7 +314,7 @@ end
     stype = get(plotattributes, :seriestype, nothing)
     if stype ∈ [:heatmap, :wireframe]
         # heatmap
-        data(x), data(y), permutedims(data(z)) ./ scaling
+        data(x), data(y), permutedims(_realdata(z)) ./ scaling
     else
         # default
 
@@ -355,6 +337,7 @@ end
         setpalette = :seriescolor ∉ keys(plotattributes) ||
                      :linecolor ∉ keys(plotattributes)
 
+        zreal = _realdata(z)
         xones = ones(length(x))
         for i in 1:length(y)
             @series begin
@@ -362,7 +345,7 @@ end
                 seriescolor --> i
 
                 if gradient
-                    line_z --> data(z)[:, i]  # colour by height
+                    line_z --> zreal[:, i]  # colour by height
                     palette --> :darkrainbow
                 else
                     if setpalette
@@ -371,7 +354,7 @@ end
                 end
                 primary --> (i == 1)
                 fillrange --> 0 # not currently implemented in plots for 3D data
-                data(x), xones * y[i], data(z)[:, i] / scaling
+                data(x), xones * y[i], zreal[:, i] / scaling
             end
         end
     end
@@ -471,7 +454,7 @@ end
             seriescolor := poscolor_c
             primary := false
             label := nothing
-            data(x), data(y), permutedims(data(dfwd))
+            data(x), data(y), permutedims(_realdata(dfwd))
         end
         if negcontours
             @series begin
@@ -479,7 +462,7 @@ end
                 seriescolor := negcolor_c
                 primary := false
                 label := nothing
-                data(x), data(y), permutedims(data(dfwd))
+                data(x), data(y), permutedims(_realdata(dfwd))
             end
         end
         @series begin
@@ -535,6 +518,7 @@ end
             throw(ArgumentError("normalize must be true, false or a reference spectrum"))
         end
 
+        zreal = _realdata(z)
         xones = ones(length(x))
         for i in 1:length(y)
             @series begin
@@ -542,7 +526,7 @@ end
                 seriescolor --> j
                 primary --> (i == 1)
                 fillrange --> 0
-                data(x), xones * y[i], data(z)[:, i] / scaling
+                data(x), xones * y[i], zreal[:, i] / scaling
             end
         end
     end

--- a/ext/PlotsExt.jl
+++ b/ext/PlotsExt.jl
@@ -36,6 +36,27 @@ function axislabel(dim::NMRDimension)
     end
 end
 
+# Multicomplex preprocessing: extract real part before delegating to existing recipes
+@recipe function f(A::NMRData{<:Multicomplex,1,Tuple{D}}) where {D<:FrequencyDimension}
+    rebuild(A; data=realest.(parent(A)))
+end
+
+@recipe function f(A::NMRData{<:Multicomplex,1,Tuple{D}}) where {D<:NonFrequencyDimension}
+    rebuild(A; data=realest.(parent(A)))
+end
+
+@recipe function f(A::NMRData{<:Multicomplex,2})
+    rebuild(A; data=realest.(parent(A)))
+end
+
+@recipe function f(v::Vector{<:NMRData{<:Multicomplex,1}})
+    [rebuild(A; data=realest.(parent(A))) for A in v]
+end
+
+@recipe function f(v::Vector{D}) where {D<:NMRData{<:Multicomplex,2}}
+    [rebuild(A; data=realest.(parent(A))) for A in v]
+end
+
 # 1D plot (frequency)
 @recipe function f(A::NMRData{T,1,Tuple{D}}; normalize=true) where {T,D<:FrequencyDimension}
     Afwd = reorder(A, ForwardOrdered) # make sure data axes are in forwards order

--- a/test/plotsext_test.jl
+++ b/test/plotsext_test.jl
@@ -76,6 +76,31 @@ end
 #     @test_throws Exception Plots.RecipesBase.apply_recipe(Dict{Symbol,Any}(:normalize => "invalid"), dat1)
 # end
 
+@testset "PlotsExt: Multicomplex 2D" begin
+    datMC = loadnmr(artifact"2D_HN"; allcomponents=true)
+    @test parent(datMC) isa Matrix{<:Multicomplex}
+
+    # Recipe should strip multicomplex and return a real-valued NMRData
+    pr = Plots.RecipesBase.apply_recipe(Dict{Symbol,Any}(), datMC)
+    result = pr[1].args[1]
+    @test result isa NMRData
+    @test eltype(result) <: Real
+    @test label(result) == "13C,15N ubiquitin"
+end
+
+@testset "PlotsExt: Multicomplex 1D (slice)" begin
+    datMC2D = loadnmr(artifact"2D_HN"; allcomponents=true)
+    datMC = datMC2D[:, 1]
+    @test parent(datMC) isa AbstractVector{<:Multicomplex}
+
+    # Recipe should strip multicomplex and return a real-valued NMRData
+    pr = Plots.RecipesBase.apply_recipe(Dict{Symbol,Any}(), datMC)
+    result = pr[1].args[1]
+    @test result isa NMRData
+    @test eltype(result) <: Real
+    @test dims(result, 1) isa FrequencyDimension
+end
+
 @testset "PlotsExt: visual regression testing" begin
     dat1 = exampledata("1D_19F")
     @plottest begin

--- a/test/plotsext_test.jl
+++ b/test/plotsext_test.jl
@@ -80,12 +80,10 @@ end
     datMC = loadnmr(artifact"2D_HN"; allcomponents=true)
     @test parent(datMC) isa Matrix{<:Multicomplex}
 
-    # Recipe should strip multicomplex and return a real-valued NMRData
     pr = Plots.RecipesBase.apply_recipe(Dict{Symbol,Any}(), datMC)
-    result = pr[1].args[1]
-    @test result isa NMRData
-    @test eltype(result) <: Real
-    @test label(result) == "13C,15N ubiquitin"
+
+    @test pr[1].plotattributes[:normalize] == true
+    @test label(pr[1].args[2]) == "13C,15N ubiquitin"
 end
 
 @testset "PlotsExt: Multicomplex 1D (slice)" begin
@@ -93,12 +91,10 @@ end
     datMC = datMC2D[:, 1]
     @test parent(datMC) isa AbstractVector{<:Multicomplex}
 
-    # Recipe should strip multicomplex and return a real-valued NMRData
+    # 1D recipe goes all the way to series data in one apply_recipe call
     pr = Plots.RecipesBase.apply_recipe(Dict{Symbol,Any}(), datMC)
-    result = pr[1].args[1]
-    @test result isa NMRData
-    @test eltype(result) <: Real
-    @test dims(result, 1) isa FrequencyDimension
+    @test pr[1].plotattributes[:xflip] == true
+    @test eltype(pr[1].args[2]) <: Real
 end
 
 @testset "PlotsExt: visual regression testing" begin


### PR DESCRIPTION
Add @recipe methods for NMRData with Multicomplex element types that
call realest.(parent(A)) to extract the real component before rebuilding
and delegating to the existing Float64 recipes. Covers 1D (frequency and
non-frequency dims), 2D, and vectors of 1D/2D Multicomplex data.

https://claude.ai/code/session_01Q7i52HPUti4JY774pioemV