### PR TITLE
Fix docs build errors: add channel docstring and missing @autodocs sections

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -1,5 +1,11 @@
 # API
 
+## NMRTools
+
+```@autodocs
+Modules = [NMRTools]
+```
+
 ## NMRBase
 
 ```@autodocs
@@ -10,4 +16,10 @@ Modules = [NMRTools.NMRBase]
 
 ```@autodocs
 Modules = [NMRTools.NMRIO]
+```
+
+## SchemaMigrate
+
+```@autodocs
+Modules = [NMRTools.NMRIO.SchemaMigrate]
 ```

--- a/src/NMRBase/metadata.jl
+++ b/src/NMRBase/metadata.jl
@@ -180,6 +180,16 @@ See also [`acqus`](@ref), [`metadata`](@ref).
 function channels end
 channels(A::Union{AbstractNMRData,NMRExperiment}) = metadata(A, :channels)
 
+"""
+    channel(nmrdata, label)
+    channel(nmrdata, nucleus)
+    channel(nmrdata, string)
+
+Return a single channel dictionary for the given spectrometer channel.
+
+See [`channels`](@ref) for the full description of the channel API and the keys
+available in the returned dictionary.
+"""
 function channel end
 function channel(A::Union{AbstractNMRData,NMRExperiment}, label::Symbol)
     ch = channels(A)

--- a/src/NMRIO/lists.jl
+++ b/src/NMRIO/lists.jl
@@ -37,7 +37,7 @@ Base.setindex!(f::FQList, v, i::Int) = (f.values[i] = v)
     withreference(f::FQList, channel) -> FQList
 
 Return a copy of frequency list `f` with its reference base and carrier frequencies
-(`:bf`, `:sfo`) populated from a channel dictionary (see [`channel`](@ref)). This
+(`:bf`, `:sfo`) populated from a channel dictionary (see [`channel`](@ref NMRTools.NMRBase.channel)). This
 makes the list self-describing, so it can be converted to ppm or Hz without a
 detected frequency axis.
 """


### PR DESCRIPTION
- Add a docstring to `channel` (distinct from `channels`) so that @ref links
  and the @autodocs block can resolve NMRTools.NMRBase.channel
- Fix the cross-module @ref in lists.jl to use the fully-qualified form
  @ref NMRTools.NMRBase.channel, per the NMRIO→NMRBase cross-module rule
- Add NMRTools and SchemaMigrate @autodocs sections to api.md so that the
  nmrplot, nmrplot!, SchemaMigrate, loadsample, and updatetolatestschema!
  docstrings are included in the manual and the missing-docs warning is resolved

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0135LDhxMNRAWsdrFPeLqG23